### PR TITLE
add apiVersion parameter

### DIFF
--- a/pyeapi/eapilib.py
+++ b/pyeapi/eapilib.py
@@ -346,6 +346,8 @@ class EapiConnection(object):
         reqid = id(self) if reqid is None else reqid
         params = {'version': 1, 'cmds': commands, 'format': encoding}
         streaming = False
+        if 'apiVersion' in kwargs:
+            params['version'] = kwargs['apiVersion']        
         if 'autoComplete' in kwargs:
             params['autoComplete'] = kwargs['autoComplete']
         if 'expandAliases' in kwargs:


### PR DESCRIPTION
Add option to specify the API version as EOS doesn't return all VRFs for the command "show ip route vrf all summary" in version 1 of the API. See Arista case 501384.
Example
connection.execute('show ip route vrf all summary',apiVersion='latest')